### PR TITLE
refactor: remove historical sensor dependency for HA 2026 compatibility

### DIFF
--- a/custom_components/electric_ireland_insights/manifest.json
+++ b/custom_components/electric_ireland_insights/manifest.json
@@ -13,8 +13,7 @@
   "loggers": ["electric_ireland_insights"],
   "requirements": [
     "beautifulsoup4~=4.12.3",
-    "homeassistant-historical-sensor==2.0.0rc4",
     "requests~=2.32.3"
   ],
-  "version": "0.2.3"
+  "version": "0.2.4-fork1"
 }

--- a/custom_components/electric_ireland_insights/sensor_base.py
+++ b/custom_components/electric_ireland_insights/sensor_base.py
@@ -1,183 +1,145 @@
 import asyncio
-import itertools
 import logging
-import statistics
-from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, UTC
-from typing import List
+from typing import Any
 
-from homeassistant.components.recorder.models import StatisticData, StatisticMetaData, StatisticMeanType
-from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
-
-from homeassistant_historical_sensor import (
-    HistoricalSensor,
-    HistoricalState,
-    PollUpdateMixin,
-)
+from homeassistant.components.sensor import SensorDeviceClass, SensorEntity, SensorStateClass
 
 from .api import ElectricIrelandScraper
-from .const import DOMAIN, LOOKUP_DAYS, PARALLEL_DAYS
-
+from .const import DOMAIN
 
 LOGGER = logging.getLogger(DOMAIN)
 
 
-class Sensor(PollUpdateMixin, HistoricalSensor, SensorEntity):
-    #
-    # Base clases:
-    # - SensorEntity: This is a sensor, obvious
-    # - HistoricalSensor: This sensor implements historical sensor methods
-    # - PollUpdateMixin: Historical sensors disable poll, this mixing
-    #                    reenables poll only for historical states and not for
-    #                    present state
-    #
+class Sensor(SensorEntity):
+    """Base sensor for Electric Ireland metrics.
 
-    def __init__(self, device_id: str, ei_api: ElectricIrelandScraper, name: str, metric: str, measurement_unit: str,
-                 device_class: SensorDeviceClass):
+    This forked version intentionally does NOT use homeassistant-historical-sensor.
+    It provides a normal HA sensor state (yesterday's total), which is stable and
+    compatible with newer Home Assistant versions.
+    """
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        device_id: str,
+        ei_api: ElectricIrelandScraper,
+        name: str,
+        metric: str,
+        measurement_unit: str,
+        device_class: SensorDeviceClass,
+    ) -> None:
         super().__init__()
 
-        self._attr_has_entity_name = True
+        self._api = ei_api
+        self._metric = metric
+        self._device_id = device_id
+
         self._attr_name = f"Electric Ireland {name}"
-
         self._attr_unique_id = f"{DOMAIN}_{metric}_{device_id}"
-        self._attr_entity_id = f"{DOMAIN}_{metric}_{device_id}"
 
-        self._attr_entity_registry_enabled_default = True
-        self._attr_state = None
-
-        # Define whatever you are
         self._attr_native_unit_of_measurement = measurement_unit
         self._attr_device_class = device_class
 
-        self._api: ElectricIrelandScraper = ei_api
-        self._metric = metric
+        # This sensor represents a daily total (yesterday).
+        # For energy, HA expects total or total_increasing. Daily totals are "total".
+        if device_class == SensorDeviceClass.ENERGY:
+            self._attr_state_class = SensorStateClass.TOTAL
+        elif device_class == SensorDeviceClass.MONETARY:
+            self._attr_state_class = SensorStateClass.TOTAL
+        else:
+            self._attr_state_class = None
 
-    async def async_added_to_hass(self) -> None:
-        await super().async_added_to_hass()
+        self._attr_native_value = None
+        self._attr_extra_state_attributes = {}
 
-    async def async_update_historical(self):
-        # Fill `HistoricalSensor._attr_historical_states` with HistoricalState's
-        # This functions is equivaled to the `Sensor.async_update` from
-        # HomeAssistant core
-        #
-        # Important: You must provide datetime with tzinfo
+    async def async_update(self) -> None:
+        """Fetch and update yesterday's total for this metric."""
 
         loop = asyncio.get_running_loop()
 
-        await loop.run_in_executor(None, self._api.refresh_credentials)
-        scraper = self._api.scraper
-
-        if not scraper:
-            LOGGER.error("Failed to get scraper - login may have failed")
+        # Refresh credentials (run in executor if it's blocking)
+        try:
+            await loop.run_in_executor(None, self._api.refresh_credentials)
+        except Exception:  # noqa: BLE001
+            LOGGER.exception("Failed to refresh Electric Ireland credentials")
+            self._attr_native_value = None
             return
 
-        hist_states: List[HistoricalState] = []
+        scraper = self._api.scraper
+        if not scraper:
+            LOGGER.error("Failed to get scraper - login may have failed")
+            self._attr_native_value = None
+            return
 
         now = datetime.now(UTC)
-        # Build a datetime for "yesterday" since data is never published on the same day
-        yesterday = datetime(year=now.year, month=now.month, day=now.day, tzinfo=UTC) - timedelta(days=1)
+        yesterday = datetime(year=now.year, month=now.month,
+                             day=now.day, tzinfo=UTC) - timedelta(days=1)
 
-        executor_results = []
+        # Fetch datapoints for yesterday. The original integration expects datapoints
+        # with keys including `intervalEnd` and your metric field (kWh/cost).
+        try:
+            datapoints = await loop.run_in_executor(None, scraper.get_data, yesterday)
+        except Exception:  # noqa: BLE001
+            LOGGER.exception(
+                "Failed to fetch Electric Ireland data for %s", yesterday.date())
+            self._attr_native_value = None
+            return
 
-        with ThreadPoolExecutor(max_workers=PARALLEL_DAYS) as executor:
-            current_date = yesterday - timedelta(days=LOOKUP_DAYS)
-            while current_date <= yesterday:
-                LOGGER.debug(f"Submitting {current_date}")
-                results = loop.run_in_executor(executor, scraper.get_data, current_date)
-                executor_results.append(results)
-                current_date += timedelta(days=1)
+        if not datapoints:
+            LOGGER.warning("No datapoints returned for %s", yesterday.date())
+            self._attr_native_value = None
+            self._attr_extra_state_attributes = {
+                "date": str(yesterday.date()),
+                "points": 0,
+            }
+            return
 
-        LOGGER.info("Finished launching jobs")
+        total = 0.0
+        valid_points = 0
+        last_interval_end: int | None = None
 
-        # For every launched job
-        for executor_result in executor_results:
-            # And now we parse the datapoints
-            for datapoint in await executor_result:
-                state = datapoint.get(self._metric)
-                dt = datetime.fromtimestamp(datapoint.get("intervalEnd"), tz=UTC)
-                hist_states.append(HistoricalState(
-                    state=state,
-                    dt=dt,
-                ))
+        for dp in datapoints:
+            value = dp.get(self._metric)
+            interval_end = dp.get("intervalEnd")
 
-        hist_states.sort(key=lambda d: d.dt)
+            if interval_end is not None:
+                try:
+                    last_interval_end = max(
+                        last_interval_end or interval_end, interval_end)
+                except TypeError:
+                    # If intervalEnd is malformed, ignore it
+                    pass
 
-        valid_datapoints: List[HistoricalState] = []
-        null_datapoints: List[HistoricalState] = []
-        invalid_datapoints: List[HistoricalState] = []
-        for hist_state in hist_states:
-            if hist_state.state is None:
-                null_datapoints.append(hist_state)
+            if value is None:
                 continue
-            if not isinstance(hist_state.state, (int, float,)):
-                invalid_datapoints.append(hist_state)
+            if not isinstance(value, (int, float)):
                 continue
-            valid_datapoints.append(hist_state)
 
-        if null_datapoints:
-            min_dt, max_dt = null_datapoints[0].dt, null_datapoints[len(null_datapoints) - 1].dt
-            LOGGER.info(f"Found {len(null_datapoints)} null datapoints, ranging from {min_dt} to {max_dt}")
+            total += float(value)
+            valid_points += 1
 
-        if invalid_datapoints:
-            LOGGER.warning(f"Found {len(invalid_datapoints)} invalid datapoints!")
-
-        if not valid_datapoints:
-            LOGGER.error("Found no valid datapoints!")
+        # If nothing usable, mark unknown
+        if valid_points == 0:
+            LOGGER.warning("No valid datapoints for metric '%s' on %s",
+                           self._metric, yesterday.date())
+            self._attr_native_value = None
         else:
-            min_dt, max_dt = valid_datapoints[0].dt, valid_datapoints[len(valid_datapoints) - 1].dt
-            LOGGER.info(f"Found {len(valid_datapoints)} valid datapoints, ranging from {min_dt} to {max_dt}")
+            # Round: energy often 3dp, cost often 2dp; keep it simple and not over-round here.
+            self._attr_native_value = total
 
-        self._attr_historical_states = [d for d in hist_states if d.state]
+        attrs: dict[str, Any] = {
+            "date": str(yesterday.date()),
+            "points": len(datapoints),
+            "valid_points": valid_points,
+        }
 
-    @property
-    def statistic_id(self) -> str:
-        return self.entity_id
+        if last_interval_end is not None:
+            try:
+                attrs["last_interval_end"] = datetime.fromtimestamp(
+                    last_interval_end, tz=UTC).isoformat()
+            except Exception:  # noqa: BLE001
+                attrs["last_interval_end"] = last_interval_end
 
-    def get_statistic_metadata(self) -> StatisticMetaData:
-        #
-        # Add sum and mean to base statistics metadata
-        # Important: HistoricalSensor.get_statistic_metadata returns an
-        # internal source by default.
-        #
-        meta = super().get_statistic_metadata()
-        meta["has_sum"] = True
-        meta["mean_type"] = StatisticMeanType.ARITHMETIC
-
-        return meta
-
-    async def async_calculate_statistic_data(
-            self, hist_states: list[HistoricalState], *, latest: dict | None = None
-    ) -> list[StatisticData]:
-        #
-        # Group historical states by hour
-        # Calculate sum, mean, etc...
-        #
-
-        accumulated = latest["sum"] if latest else 0
-
-        def hour_block_for_hist_state(hist_state: HistoricalState) -> datetime:
-            # XX:00:00 states belongs to previous hour block
-            if hist_state.dt.minute == 0 and hist_state.dt.second == 0:
-                dt = hist_state.dt - timedelta(hours=1)
-                return dt.replace(minute=0, second=0, microsecond=0)
-
-            else:
-                return hist_state.dt.replace(minute=0, second=0, microsecond=0)
-
-        ret = []
-        for dt, collection_it in itertools.groupby(hist_states, key=hour_block_for_hist_state):
-            collection = list(collection_it)
-            mean = statistics.mean([x.state for x in collection])
-            partial_sum = sum([x.state for x in collection])
-            accumulated = accumulated + partial_sum
-
-            ret.append(
-                StatisticData(
-                    start=dt,
-                    state=partial_sum,
-                    mean=mean,
-                    sum=accumulated,
-                )
-            )
-
-        return ret
+        self._attr_extra_state_attributes = attrs

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,2 @@
 beautifulsoup4~=4.12.3
-homeassistant~=2025.12.1
-homeassistant-historical-sensor==2.0.0rc4
 requests~=2.32.3


### PR DESCRIPTION
Home Assistant 2026.x removed internal APIs relied upon by
homeassistant-historical-sensor (e.g. _friendly_name_internal),
causing Electric Ireland sensors to fail during setup.

This change removes the dependency on homeassistant-historical-sensor
and refactors the integration to use standard SensorEntity behaviour.

Changes:
- Removed homeassistant-historical-sensor from requirements
- Removed Home Assistant version pin from requirements
- Replaced HistoricalSensor-based implementation with native SensorEntity
- Implemented async_update to fetch and expose yesterday’s totals directly
- Set appropriate device_class and state_class values
- Bumped integration version

This restores compatibility with current Home Assistant releases
and removes reliance on internal recorder/statistics APIs.