### PR TITLE
Restore compatibility with newer Home Assistant installations and fix a couple of issues

### DIFF
--- a/custom_components/electric_ireland_insights/manifest.json
+++ b/custom_components/electric_ireland_insights/manifest.json
@@ -14,7 +14,7 @@
   "requirements": [
     "beautifulsoup4~=4.12.3",
     "homeassistant-historical-sensor==2.0.0rc4",
-    "requests~=2.32.3"
+    "requests>=2.32.3"
   ],
   "version": "0.2.3"
 }

--- a/custom_components/electric_ireland_insights/sensor_base.py
+++ b/custom_components/electric_ireland_insights/sensor_base.py
@@ -156,7 +156,7 @@ class Sensor(PollUpdateMixin, HistoricalSensor, SensorEntity):
         # Calculate sum, mean, etc...
         #
 
-        accumulated = latest.get("sum") or 0 if latest else 0
+        accumulated = latest.get("sum", 0) if latest else 0
 
         def hour_block_for_hist_state(hist_state: HistoricalState) -> datetime:
             # XX:00:00 states belongs to previous hour block

--- a/custom_components/electric_ireland_insights/sensor_base.py
+++ b/custom_components/electric_ireland_insights/sensor_base.py
@@ -55,6 +55,9 @@ class Sensor(PollUpdateMixin, HistoricalSensor, SensorEntity):
     async def async_added_to_hass(self) -> None:
         await super().async_added_to_hass()
 
+    def _friendly_name_internal(self) -> str | None:
+        return self.name or self._attr_name or "Electric Ireland Insights"
+
     async def async_update_historical(self):
         # Fill `HistoricalSensor._attr_historical_states` with HistoricalState's
         # This functions is equivaled to the `Sensor.async_update` from
@@ -153,7 +156,7 @@ class Sensor(PollUpdateMixin, HistoricalSensor, SensorEntity):
         # Calculate sum, mean, etc...
         #
 
-        accumulated = latest["sum"] if latest else 0
+        accumulated = latest.get("sum") or 0 if latest else 0
 
         def hour_block_for_hist_state(hist_state: HistoricalState) -> datetime:
             # XX:00:00 states belongs to previous hour block


### PR DESCRIPTION
This PR resolves compatibility issues with new Home Assistant versions (specifically environments running Python 3.14+) and fixes setup failures during database resets.

### Changes Implemented:                                                                                                                         

1. **Relaxed `requests` dependency in `manifest.json`**:
  - Switched `"requests~=2.32.3"` to `"requests>=2.32.3"` to avoid dependency resolution conflicts with newer packages already bundled in modern Home Assistant environments.

2. **Added `_friendly_name_internal` fallback in `sensor_base.py`**:
  - The underlying `homeassistant-historical-sensor` library monkey-patches `_friendly_name_internal()`, but this internal method has been removed from Home Assistant's core `Entity` class. Added a fallback method to the custom `Sensor` class to gracefully satisfy the library's expectation.

3. **Resolved `KeyError: 'sum'` on fresh install/restart in `sensor_base.py`**:
  - Changed `accumulated = latest["sum"]` to `latest.get("sum") or 0` to safely handle empty database states when setting up the statistics data for the first time.