### PR TITLE
FixTypeError when 'latest' statistics sum is None

### DIFF
--- a/custom_components/electric_ireland_insights/sensor_base.py
+++ b/custom_components/electric_ireland_insights/sensor_base.py
@@ -156,7 +156,7 @@ class Sensor(PollUpdateMixin, HistoricalSensor, SensorEntity):
         # Calculate sum, mean, etc...
         #
 
-        accumulated = latest.get("sum", 0) if latest else 0
+        accumulated = (latest.get("sum") or 0) if latest else 0
 
         def hour_block_for_hist_state(hist_state: HistoricalState) -> datetime:
             # XX:00:00 states belongs to previous hour block


### PR DESCRIPTION
Hi Diego, it looks like when addressing the nitpick in the previous PR, we inadvertently introduced a new error 😢 

In sensor_base.py we ended up calculating the following:

accumulated = latest.get("sum", 0) if latest else 0

The issue is that `.get(key, default)` only returns the default value if the key is absent from the dictionary. If the key exists but its value is explicitly stored as None (e.g. `latest = {"sum": None}`), which somehow happened when I updated to the latest version), accumulated is set to None, causing a TypeError later on line 175: accumulated = accumulated + partial_sum

By changing it to  (latest.get("sum") or 0), we use Python's falsy evaluation. If "sum" is missing _or_ if its value is None, it evaluates to  0, making it robust against empty database entries. I also added the explicit parentheses to avoid the ambiguity that you previously pointed out.

Note that this issue doesn't affect fresh installs, only upgrades where the existing statistics database is reset.