### PR TITLE
fix: replace homeassistant-historical-sensor with native HA statistics

### DIFF
--- a/custom_components/electric_ireland_insights/__init__.py
+++ b/custom_components/electric_ireland_insights/__init__.py
@@ -1,32 +1,42 @@
 import logging
+from datetime import timedelta
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.typing import ConfigType
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import DOMAIN
-
+from .api import ElectricIrelandScraper
+from .const import DOMAIN, DEFAULT_LOOKUP_DAYS
 
 LOGGER = logging.getLogger(DOMAIN)
 
 PLATFORMS = ["sensor"]
 
 
-async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Set up the Electric Ireland Insights component."""
-    # Ensure the domain is registered in the hass.data store
-    hass.data.setdefault(DOMAIN, {})
-    LOGGER.debug("Electric Ireland Insights component initialized.")
-    return True
-
-
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Electric Ireland Insights from a config entry."""
-    if DOMAIN not in hass.data:
-        hass.data[DOMAIN] = {}
+    hass.data.setdefault(DOMAIN, {})
 
-    # Store entry data in hass.data for later use
-    hass.data[DOMAIN][entry.entry_id] = entry.data
+    ei_api = ElectricIrelandScraper(
+        entry.data["username"],
+        entry.data["password"],
+        entry.data["account_number"],
+    )
+
+    lookup_days = int(entry.data.get("lookup_days", DEFAULT_LOOKUP_DAYS))
+
+    coordinator = DataUpdateCoordinator(
+        hass,
+        LOGGER,
+        name=DOMAIN,
+        update_method=lambda: hass.async_add_executor_job(ei_api.fetch_all, lookup_days),
+        update_interval=timedelta(hours=1),
+    )
+
+    await coordinator.async_config_entry_first_refresh()
+
+    # Store coordinator in hass.data for later use
+    hass.data[DOMAIN][entry.entry_id] = coordinator
 
     # Forward the entry setup to the sensor platform
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/custom_components/electric_ireland_insights/api.py
+++ b/custom_components/electric_ireland_insights/api.py
@@ -1,11 +1,12 @@
 import logging
-from datetime import datetime
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timedelta, UTC
 
 import requests
 from bs4 import BeautifulSoup
 from requests import RequestException
 
-from .const import DOMAIN
+from .const import DOMAIN, DEFAULT_LOOKUP_DAYS, PARALLEL_DAYS
 
 
 LOGGER = logging.getLogger(DOMAIN)
@@ -34,6 +35,31 @@ class ElectricIrelandScraper:
     @property
     def scraper(self):
         return self.__scraper
+
+    def fetch_all(self, lookup_days=DEFAULT_LOOKUP_DAYS):
+        """Fetch all datapoints for the past lookup_days days. Returns list of dicts."""
+        self.refresh_credentials()
+        scraper = self.__scraper
+        if not scraper:
+            return []
+
+        now = datetime.now(UTC)
+        yesterday = datetime(now.year, now.month, now.day, tzinfo=UTC) - timedelta(days=1)
+        start = yesterday - timedelta(days=lookup_days)
+
+        dates = []
+        current = start
+        while current <= yesterday:
+            dates.append(current)
+            current += timedelta(days=1)
+
+        results = []
+        with ThreadPoolExecutor(max_workers=PARALLEL_DAYS) as pool:
+            futures = [pool.submit(scraper.get_data, d) for d in dates]
+            for f in futures:
+                results.extend(f.result())
+
+        return results
 
     def __login_and_get_meter_ids(self, session):
         # REQUEST 1: Get the Source token, and initialize the session

--- a/custom_components/electric_ireland_insights/config_flow.py
+++ b/custom_components/electric_ireland_insights/config_flow.py
@@ -3,9 +3,9 @@ from typing import Any
 
 from homeassistant import config_entries
 from homeassistant.core import callback
-from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers.selector import NumberSelector, NumberSelectorConfig, NumberSelectorMode
 
-from .const import DOMAIN, NAME
+from .const import DOMAIN, NAME, DEFAULT_BILLING_DAY, DEFAULT_LOOKUP_DAYS
 
 @callback
 def configured_instances(hass):
@@ -18,7 +18,7 @@ def configured_instances(hass):
 class ElectricIrelandInsightsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     VERSION = 1
 
-    async def async_step_user(self, user_input: dict[str, Any] | None = None) -> FlowResult:
+    async def async_step_user(self, user_input: dict[str, Any] | None = None):
         errors = {}
 
         if user_input is not None:
@@ -31,6 +31,47 @@ class ElectricIrelandInsightsConfigFlow(config_entries.ConfigFlow, domain=DOMAIN
             vol.Required("username"): str,
             vol.Required("password"): str,
             vol.Required("account_number"): str,
+            vol.Required("billing_day", default=DEFAULT_BILLING_DAY): NumberSelector(
+                NumberSelectorConfig(min=1, max=31, step=1, mode=NumberSelectorMode.BOX)
+            ),
+            vol.Required("lookup_days", default=DEFAULT_LOOKUP_DAYS): NumberSelector(
+                NumberSelectorConfig(min=7, max=365, step=1, mode=NumberSelectorMode.BOX)
+            ),
         })
 
         return self.async_show_form(step_id="user", data_schema=data_schema, errors=errors)
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(config_entry):
+        return ElectricIrelandInsightsOptionsFlow()
+
+
+class ElectricIrelandInsightsOptionsFlow(config_entries.OptionsFlow):
+    # No __init__ override — self.config_entry is set automatically by HA 2024.4+
+
+    async def async_step_init(self, user_input: dict[str, Any] | None = None):
+        if user_input is not None:
+            self.hass.config_entries.async_update_entry(
+                self.config_entry,
+                data={
+                    **self.config_entry.data,
+                    "billing_day": int(user_input["billing_day"]),
+                    "lookup_days": int(user_input["lookup_days"]),
+                },
+            )
+            return self.async_create_entry(title="", data={})
+
+        current_billing_day = int(self.config_entry.data.get("billing_day", DEFAULT_BILLING_DAY))
+        current_lookup_days = int(self.config_entry.data.get("lookup_days", DEFAULT_LOOKUP_DAYS))
+
+        data_schema = vol.Schema({
+            vol.Required("billing_day", default=current_billing_day): NumberSelector(
+                NumberSelectorConfig(min=1, max=31, step=1, mode=NumberSelectorMode.BOX)
+            ),
+            vol.Required("lookup_days", default=current_lookup_days): NumberSelector(
+                NumberSelectorConfig(min=7, max=365, step=1, mode=NumberSelectorMode.BOX)
+            ),
+        })
+
+        return self.async_show_form(step_id="init", data_schema=data_schema)

--- a/custom_components/electric_ireland_insights/const.py
+++ b/custom_components/electric_ireland_insights/const.py
@@ -1,5 +1,6 @@
 DOMAIN = "electric_ireland_insights"
 NAME = "Electric Ireland Insights"
 
-LOOKUP_DAYS = 30
+DEFAULT_LOOKUP_DAYS = 30
 PARALLEL_DAYS = 5
+DEFAULT_BILLING_DAY = 1

--- a/custom_components/electric_ireland_insights/manifest.json
+++ b/custom_components/electric_ireland_insights/manifest.json
@@ -13,8 +13,7 @@
   "loggers": ["electric_ireland_insights"],
   "requirements": [
     "beautifulsoup4~=4.12.3",
-    "homeassistant-historical-sensor==2.0.0rc4",
     "requests>=2.32.3"
   ],
-  "version": "0.2.5"
+  "version": "0.3.0"
 }

--- a/custom_components/electric_ireland_insights/sensor.py
+++ b/custom_components/electric_ireland_insights/sensor.py
@@ -1,48 +1,99 @@
+import calendar
 import logging
+from datetime import datetime, timezone
 
-from homeassistant.components.sensor import SensorDeviceClass
+from homeassistant.components.sensor import SensorDeviceClass, SensorEntity, SensorStateClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfEnergy, CURRENCY_EURO
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.typing import DiscoveryInfoType
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .api import ElectricIrelandScraper
+from .const import DOMAIN, DEFAULT_BILLING_DAY, DEFAULT_LOOKUP_DAYS
 from .sensor_base import Sensor
-
-PLATFORM = "sensor"
 
 LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
-        hass: HomeAssistant,
-        config_entry: ConfigEntry,
-        async_add_devices: AddEntitiesCallback,
-        discovery_info: DiscoveryInfoType | None = None,  # noqa DiscoveryInfoType | None
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_devices: AddEntitiesCallback,
 ):
-    username = config_entry.data["username"]
-    password = config_entry.data["password"]
-    account_number = config_entry.data["account_number"]
+    coordinator = hass.data[DOMAIN][config_entry.entry_id]
+    # NumberSelector returns float — cast to int
+    billing_day = int(config_entry.data.get("billing_day", DEFAULT_BILLING_DAY))
+    lookup_days = int(config_entry.data.get("lookup_days", DEFAULT_LOOKUP_DAYS))
 
-    ei_api = ElectricIrelandScraper(username, password, account_number)
-
-    sensors = [
-        ConsumptionSensor(device_id=config_entry.entry_id, ei_api=ei_api),
-        CostSensor(device_id=config_entry.entry_id, ei_api=ei_api),
-    ]
-    async_add_devices(sensors)
+    async_add_devices([
+        ConsumptionSensor(coordinator, config_entry.entry_id, lookup_days),
+        CostSensor(coordinator, config_entry.entry_id, lookup_days),
+        BillingConsumptionSensor(coordinator, config_entry.entry_id, billing_day),
+        BillingCostSensor(coordinator, config_entry.entry_id, billing_day),
+    ])
 
 
 class ConsumptionSensor(Sensor):
-    def __init__(self, device_id: str, ei_api: ElectricIrelandScraper):
-        super().__init__(device_id, ei_api,
-                         "Consumption", "consumption",
-                         UnitOfEnergy.KILO_WATT_HOUR, SensorDeviceClass.ENERGY)
+    def __init__(self, coordinator, device_id, lookup_days):
+        super().__init__(coordinator, device_id, "Consumption", "consumption",
+                         UnitOfEnergy.KILO_WATT_HOUR, SensorDeviceClass.ENERGY, unit_class="energy",
+                         lookup_days=lookup_days)
 
 
 class CostSensor(Sensor):
-    def __init__(self, device_id: str, ei_api: ElectricIrelandScraper):
-        super().__init__(device_id, ei_api,
-                         "Cost", "cost",
-                         CURRENCY_EURO, SensorDeviceClass.MONETARY)
+    def __init__(self, coordinator, device_id, lookup_days):
+        super().__init__(coordinator, device_id, "Cost", "cost",
+                         CURRENCY_EURO, SensorDeviceClass.MONETARY, unit_class=None,
+                         lookup_days=lookup_days)
+
+
+def _billing_start(now: datetime, billing_day: int) -> datetime:
+    # Clamp billing_day to the actual number of days in the target month to
+    # avoid ValueError when billing_day=31 but the month has fewer days.
+    def safe_day(year, month, day):
+        return min(day, calendar.monthrange(year, month)[1])
+
+    if now.day >= billing_day:
+        return datetime(now.year, now.month, safe_day(now.year, now.month, billing_day), tzinfo=timezone.utc)
+    prev_month = now.month - 1 or 12
+    prev_year = now.year if now.month > 1 else now.year - 1
+    return datetime(prev_year, prev_month, safe_day(prev_year, prev_month, billing_day), tzinfo=timezone.utc)
+
+
+class BillingSensor(CoordinatorEntity, SensorEntity):
+    _attr_has_entity_name = True
+    _attr_entity_registry_enabled_default = True
+    _attr_state_class = SensorStateClass.TOTAL
+
+    def __init__(self, coordinator, device_id, name, metric, unit, device_class, billing_day):
+        super().__init__(coordinator)
+        self._attr_name = f"Electric Ireland {name}"
+        self._attr_unique_id = f"{DOMAIN}_{metric}_billing_{device_id}"
+        self._attr_native_unit_of_measurement = unit
+        self._attr_device_class = device_class
+        self._metric = metric
+        self._billing_day = billing_day
+
+    @property
+    def native_value(self):
+        datapoints = self.coordinator.data or []
+        cutoff = _billing_start(datetime.now(timezone.utc), self._billing_day)
+        total = sum(
+            dp[self._metric]
+            for dp in datapoints
+            if isinstance(dp.get(self._metric), (int, float))
+            and datetime.fromtimestamp(dp["intervalEnd"], tz=timezone.utc) >= cutoff
+        )
+        return round(total, 2)
+
+
+class BillingConsumptionSensor(BillingSensor):
+    def __init__(self, coordinator, device_id, billing_day):
+        super().__init__(coordinator, device_id, "Consumption (Billing Cycle)", "consumption",
+                         UnitOfEnergy.KILO_WATT_HOUR, SensorDeviceClass.ENERGY, billing_day)
+
+
+class BillingCostSensor(BillingSensor):
+    def __init__(self, coordinator, device_id, billing_day):
+        super().__init__(coordinator, device_id, "Cost (Billing Cycle)", "cost",
+                         CURRENCY_EURO, SensorDeviceClass.MONETARY, billing_day)

--- a/custom_components/electric_ireland_insights/sensor.py
+++ b/custom_components/electric_ireland_insights/sensor.py
@@ -24,27 +24,37 @@ async def async_setup_entry(
     # NumberSelector returns float — cast to int
     billing_day = int(config_entry.data.get("billing_day", DEFAULT_BILLING_DAY))
     lookup_days = int(config_entry.data.get("lookup_days", DEFAULT_LOOKUP_DAYS))
+    account_number = config_entry.data.get("account_number")
 
     async_add_devices([
-        ConsumptionSensor(coordinator, config_entry.entry_id, lookup_days),
-        CostSensor(coordinator, config_entry.entry_id, lookup_days),
-        BillingConsumptionSensor(coordinator, config_entry.entry_id, billing_day),
-        BillingCostSensor(coordinator, config_entry.entry_id, billing_day),
+        ConsumptionSensor(coordinator, config_entry.entry_id, lookup_days, account_number),
+        CostSensor(coordinator, config_entry.entry_id, lookup_days, account_number),
+        BillingConsumptionSensor(coordinator, config_entry.entry_id, billing_day, account_number),
+        BillingCostSensor(coordinator, config_entry.entry_id, billing_day, account_number),
     ])
 
 
 class ConsumptionSensor(Sensor):
-    def __init__(self, coordinator, device_id, lookup_days):
+    def __init__(self, coordinator, device_id, lookup_days, account_number=None):
         super().__init__(coordinator, device_id, "Consumption", "consumption",
                          UnitOfEnergy.KILO_WATT_HOUR, SensorDeviceClass.ENERGY, unit_class="energy",
-                         lookup_days=lookup_days)
+                         lookup_days=lookup_days, account_number=account_number)
 
 
 class CostSensor(Sensor):
-    def __init__(self, coordinator, device_id, lookup_days):
+    def __init__(self, coordinator, device_id, lookup_days, account_number=None):
         super().__init__(coordinator, device_id, "Cost", "cost",
                          CURRENCY_EURO, SensorDeviceClass.MONETARY, unit_class=None,
-                         lookup_days=lookup_days)
+                         lookup_days=lookup_days, account_number=account_number)
+
+    @property
+    def extra_state_attributes(self):
+        attrs = super().extra_state_attributes
+        datapoints = self.coordinator.data or []
+        cost_values = [dp["cost"] for dp in datapoints if isinstance(dp.get("cost"), (int, float))]
+        attrs["average_hourly_value"] = round(sum(cost_values) / len(cost_values), 4) if cost_values else None
+        attrs["latest_hour_value"] = cost_values[-1] if cost_values else None
+        return attrs
 
 
 def _billing_start(now: datetime, billing_day: int) -> datetime:
@@ -65,7 +75,7 @@ class BillingSensor(CoordinatorEntity, SensorEntity):
     _attr_entity_registry_enabled_default = True
     _attr_state_class = SensorStateClass.TOTAL
 
-    def __init__(self, coordinator, device_id, name, metric, unit, device_class, billing_day):
+    def __init__(self, coordinator, device_id, name, metric, unit, device_class, billing_day, account_number=None):
         super().__init__(coordinator)
         self._attr_name = f"Electric Ireland {name}"
         self._attr_unique_id = f"{DOMAIN}_{metric}_billing_{device_id}"
@@ -73,27 +83,52 @@ class BillingSensor(CoordinatorEntity, SensorEntity):
         self._attr_device_class = device_class
         self._metric = metric
         self._billing_day = billing_day
+        self._account_number = account_number
+
+    def _billing_datapoints(self):
+        cutoff = _billing_start(datetime.now(timezone.utc), self._billing_day)
+        return [
+            dp for dp in (self.coordinator.data or [])
+            if isinstance(dp.get(self._metric), (int, float))
+            and dp.get("intervalEnd") is not None
+            and datetime.fromtimestamp(dp["intervalEnd"], tz=timezone.utc) >= cutoff
+        ]
 
     @property
     def native_value(self):
-        datapoints = self.coordinator.data or []
+        return round(sum(dp[self._metric] for dp in self._billing_datapoints()), 2)
+
+    @property
+    def extra_state_attributes(self):
+        dps = self._billing_datapoints()
+        values = [dp[self._metric] for dp in dps]
+        timestamps = [datetime.fromtimestamp(dp["intervalEnd"], tz=timezone.utc) for dp in dps]
         cutoff = _billing_start(datetime.now(timezone.utc), self._billing_day)
-        total = sum(
-            dp[self._metric]
-            for dp in datapoints
-            if isinstance(dp.get(self._metric), (int, float))
-            and datetime.fromtimestamp(dp["intervalEnd"], tz=timezone.utc) >= cutoff
-        )
-        return round(total, 2)
+        period_days = (datetime.now(timezone.utc).date() - cutoff.date()).days + 1
+        return {
+            "start_date": timestamps[0].isoformat() if timestamps else cutoff.isoformat(),
+            "end_date": timestamps[-1].isoformat() if timestamps else None,
+            "period_days": period_days,
+            "hours_recorded": len(values),
+            "average_daily_value": round(sum(values) / period_days, 4) if values and period_days else None,
+        }
 
 
 class BillingConsumptionSensor(BillingSensor):
-    def __init__(self, coordinator, device_id, billing_day):
+    def __init__(self, coordinator, device_id, billing_day, account_number=None):
         super().__init__(coordinator, device_id, "Consumption (Billing Cycle)", "consumption",
-                         UnitOfEnergy.KILO_WATT_HOUR, SensorDeviceClass.ENERGY, billing_day)
+                         UnitOfEnergy.KILO_WATT_HOUR, SensorDeviceClass.ENERGY, billing_day, account_number)
 
 
 class BillingCostSensor(BillingSensor):
-    def __init__(self, coordinator, device_id, billing_day):
+    def __init__(self, coordinator, device_id, billing_day, account_number=None):
         super().__init__(coordinator, device_id, "Cost (Billing Cycle)", "cost",
-                         CURRENCY_EURO, SensorDeviceClass.MONETARY, billing_day)
+                         CURRENCY_EURO, SensorDeviceClass.MONETARY, billing_day, account_number)
+
+    @property
+    def extra_state_attributes(self):
+        attrs = super().extra_state_attributes
+        values = [dp["cost"] for dp in self._billing_datapoints()]
+        attrs["average_hourly_value"] = round(sum(values) / len(values), 4) if values else None
+        attrs["latest_hour_value"] = values[-1] if values else None
+        return attrs

--- a/custom_components/electric_ireland_insights/sensor_base.py
+++ b/custom_components/electric_ireland_insights/sensor_base.py
@@ -28,7 +28,7 @@ class Sensor(CoordinatorEntity, SensorEntity):
 
     def __init__(self, coordinator: DataUpdateCoordinator, device_id: str, name: str, metric: str,
                  unit: str, device_class: SensorDeviceClass, unit_class: str | None = None,
-                 lookup_days: int = DEFAULT_LOOKUP_DAYS):
+                 lookup_days: int = DEFAULT_LOOKUP_DAYS, account_number: str | None = None):
         super().__init__(coordinator)
 
         self._attr_name = f"Electric Ireland {name}"
@@ -39,6 +39,7 @@ class Sensor(CoordinatorEntity, SensorEntity):
         self._metric = metric
         self._unit_class = unit_class
         self._lookup_days = lookup_days
+        self._account_number = account_number
         # statistic_id includes device_id to avoid collision across multiple accounts
         self._statistic_id = f"{DOMAIN}:{metric}_{device_id.replace('-', '_').lower()}"
 
@@ -68,6 +69,8 @@ class Sensor(CoordinatorEntity, SensorEntity):
         invalid = sum(1 for dp in datapoints if dp.get(self._metric) is not None and not isinstance(dp.get(self._metric), (int, float)))
 
         return {
+            "account_number": self._account_number,
+            "period_days": self._lookup_days,
             "start_date": timestamps[0].isoformat() if timestamps else None,
             "end_date": timestamps[-1].isoformat() if timestamps else None,
             "latest_hour_timestamp": timestamps[-1].isoformat() if timestamps else None,

--- a/custom_components/electric_ireland_insights/sensor_base.py
+++ b/custom_components/electric_ireland_insights/sensor_base.py
@@ -1,186 +1,168 @@
-import asyncio
 import itertools
 import logging
 import statistics
-from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, UTC
-from typing import List
 
+from homeassistant.components.recorder import get_instance
 from homeassistant.components.recorder.models import StatisticData, StatisticMetaData, StatisticMeanType
-from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
+from homeassistant.components.recorder.statistics import async_add_external_statistics, get_last_statistics
+from homeassistant.components.sensor import SensorDeviceClass, SensorEntity, SensorStateClass
+from homeassistant.core import callback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity, DataUpdateCoordinator
 
-from homeassistant_historical_sensor import (
-    HistoricalSensor,
-    HistoricalState,
-    PollUpdateMixin,
-)
-
-from .api import ElectricIrelandScraper
-from .const import DOMAIN, LOOKUP_DAYS, PARALLEL_DAYS
-
+from .const import DOMAIN, DEFAULT_LOOKUP_DAYS
 
 LOGGER = logging.getLogger(DOMAIN)
 
 
-class Sensor(PollUpdateMixin, HistoricalSensor, SensorEntity):
+class Sensor(CoordinatorEntity, SensorEntity):
     #
-    # Base clases:
+    # Base classes:
     # - SensorEntity: This is a sensor, obvious
-    # - HistoricalSensor: This sensor implements historical sensor methods
-    # - PollUpdateMixin: Historical sensors disable poll, this mixing
-    #                    reenables poll only for historical states and not for
-    #                    present state
+    # - CoordinatorEntity: Subscribes to DataUpdateCoordinator updates
     #
 
-    def __init__(self, device_id: str, ei_api: ElectricIrelandScraper, name: str, metric: str, measurement_unit: str,
-                 device_class: SensorDeviceClass):
-        super().__init__()
+    _attr_has_entity_name = True
+    _attr_entity_registry_enabled_default = True
+    _attr_state_class = SensorStateClass.TOTAL
 
-        self._attr_has_entity_name = True
+    def __init__(self, coordinator: DataUpdateCoordinator, device_id: str, name: str, metric: str,
+                 unit: str, device_class: SensorDeviceClass, unit_class: str | None = None,
+                 lookup_days: int = DEFAULT_LOOKUP_DAYS):
+        super().__init__(coordinator)
+
         self._attr_name = f"Electric Ireland {name}"
-
+        # device_id (config entry id) is included so two accounts never share a statistic_id
         self._attr_unique_id = f"{DOMAIN}_{metric}_{device_id}"
-        self._attr_entity_id = f"{DOMAIN}_{metric}_{device_id}"
-
-        self._attr_entity_registry_enabled_default = True
-        self._attr_state = None
-
-        # Define whatever you are
-        self._attr_native_unit_of_measurement = measurement_unit
+        self._attr_native_unit_of_measurement = unit
         self._attr_device_class = device_class
-
-        self._api: ElectricIrelandScraper = ei_api
         self._metric = metric
+        self._unit_class = unit_class
+        self._lookup_days = lookup_days
+        # statistic_id includes device_id to avoid collision across multiple accounts
+        self._statistic_id = f"{DOMAIN}:{metric}_{device_id.replace('-', '_').lower()}"
 
     async def async_added_to_hass(self) -> None:
         await super().async_added_to_hass()
-
-    def _friendly_name_internal(self) -> str | None:
-        return self.name or self._attr_name or "Electric Ireland Insights"
-
-    async def async_update_historical(self):
-        # Fill `HistoricalSensor._attr_historical_states` with HistoricalState's
-        # This functions is equivaled to the `Sensor.async_update` from
-        # HomeAssistant core
-        #
-        # Important: You must provide datetime with tzinfo
-
-        loop = asyncio.get_running_loop()
-
-        await loop.run_in_executor(None, self._api.refresh_credentials)
-        scraper = self._api.scraper
-
-        if not scraper:
-            LOGGER.error("Failed to get scraper - login may have failed")
-            return
-
-        hist_states: List[HistoricalState] = []
-
-        now = datetime.now(UTC)
-        # Build a datetime for "yesterday" since data is never published on the same day
-        yesterday = datetime(year=now.year, month=now.month, day=now.day, tzinfo=UTC) - timedelta(days=1)
-
-        executor_results = []
-
-        with ThreadPoolExecutor(max_workers=PARALLEL_DAYS) as executor:
-            current_date = yesterday - timedelta(days=LOOKUP_DAYS)
-            while current_date <= yesterday:
-                LOGGER.debug(f"Submitting {current_date}")
-                results = loop.run_in_executor(executor, scraper.get_data, current_date)
-                executor_results.append(results)
-                current_date += timedelta(days=1)
-
-        LOGGER.info("Finished launching jobs")
-
-        # For every launched job
-        for executor_result in executor_results:
-            # And now we parse the datapoints
-            for datapoint in await executor_result:
-                state = datapoint.get(self._metric)
-                dt = datetime.fromtimestamp(datapoint.get("intervalEnd"), tz=UTC)
-                hist_states.append(HistoricalState(
-                    state=state,
-                    dt=dt,
-                ))
-
-        hist_states.sort(key=lambda d: d.dt)
-
-        valid_datapoints: List[HistoricalState] = []
-        null_datapoints: List[HistoricalState] = []
-        invalid_datapoints: List[HistoricalState] = []
-        for hist_state in hist_states:
-            if hist_state.state is None:
-                null_datapoints.append(hist_state)
-                continue
-            if not isinstance(hist_state.state, (int, float,)):
-                invalid_datapoints.append(hist_state)
-                continue
-            valid_datapoints.append(hist_state)
-
-        if null_datapoints:
-            min_dt, max_dt = null_datapoints[0].dt, null_datapoints[len(null_datapoints) - 1].dt
-            LOGGER.info(f"Found {len(null_datapoints)} null datapoints, ranging from {min_dt} to {max_dt}")
-
-        if invalid_datapoints:
-            LOGGER.warning(f"Found {len(invalid_datapoints)} invalid datapoints!")
-
-        if not valid_datapoints:
-            LOGGER.error("Found no valid datapoints!")
-        else:
-            min_dt, max_dt = valid_datapoints[0].dt, valid_datapoints[len(valid_datapoints) - 1].dt
-            LOGGER.info(f"Found {len(valid_datapoints)} valid datapoints, ranging from {min_dt} to {max_dt}")
-
-        self._attr_historical_states = [d for d in hist_states if d.state]
+        # Only import on startup — coordinator refresh will call _handle_coordinator_update
+        # for subsequent updates, avoiding double import on init.
+        if self.coordinator.data:
+            await self._import_statistics()
 
     @property
-    def statistic_id(self) -> str:
-        return self.entity_id
+    def native_value(self):
+        datapoints = self.coordinator.data or []
+        values = [dp[self._metric] for dp in datapoints if isinstance(dp.get(self._metric), (int, float))]
+        return round(sum(values), 2) if values else None
 
-    def get_statistic_metadata(self) -> StatisticMetaData:
-        #
-        # Add sum and mean to base statistics metadata
-        # Important: HistoricalSensor.get_statistic_metadata returns an
-        # internal source by default.
-        #
-        meta = super().get_statistic_metadata()
-        meta["has_sum"] = True
-        meta["mean_type"] = StatisticMeanType.ARITHMETIC
+    @property
+    def extra_state_attributes(self):
+        datapoints = self.coordinator.data or []
+        values = [dp[self._metric] for dp in datapoints if isinstance(dp.get(self._metric), (int, float))]
+        timestamps = [
+            datetime.fromtimestamp(dp["intervalEnd"], tz=UTC)
+            for dp in datapoints
+            if isinstance(dp.get(self._metric), (int, float))
+        ]
+        missing = sum(1 for dp in datapoints if dp.get(self._metric) is None)
+        invalid = sum(1 for dp in datapoints if dp.get(self._metric) is not None and not isinstance(dp.get(self._metric), (int, float)))
 
-        return meta
+        return {
+            "start_date": timestamps[0].isoformat() if timestamps else None,
+            "end_date": timestamps[-1].isoformat() if timestamps else None,
+            "latest_hour_timestamp": timestamps[-1].isoformat() if timestamps else None,
+            "hours_recorded": len(values),
+            "missing_hours": missing,
+            "invalid_hours": invalid,
+            "average_daily_value": round(sum(values) / self._lookup_days, 4) if values else None,
+            "max_hourly_value": max(values) if values else None,
+            "min_hourly_value": min(values) if values else None,
+        }
 
-    async def async_calculate_statistic_data(
-            self, hist_states: list[HistoricalState], *, latest: dict | None = None
-    ) -> list[StatisticData]:
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        # Coordinator fires listeners synchronously — schedule the async import as a task,
+        # then immediately update state so the sensor doesn't freeze between refreshes.
+        self.hass.async_create_task(self._import_statistics())
+        self.async_write_ha_state()
+
+    async def _import_statistics(self) -> None:
+        # Push historical datapoints into the recorder via async_add_external_statistics.
+        # This replaces the homeassistant-historical-sensor library, which caused
+        # StaleDataError races on MariaDB/SQLite (issues #4, #13).
+        datapoints = self.coordinator.data or []
+        if not datapoints:
+            return
+
+        hist = sorted(
+            [
+                (datetime.fromtimestamp(dp["intervalEnd"], tz=UTC), dp.get(self._metric))
+                for dp in datapoints
+                if isinstance(dp.get(self._metric), (int, float))
+            ],
+            key=lambda x: x[0],
+        )
+
+        if not hist:
+            return
+
+        # Find the last recorded sum so we can resume accumulation from that point.
+        # We only re-import buckets that are newer than what's already in the DB,
+        # so the cumulative sum is never double-counted across refreshes.
+        last_stats = await get_instance(self.hass).async_add_executor_job(
+            lambda: get_last_statistics(self.hass, 1, self._statistic_id, True, {"sum", "start"})
+        )
+        if last_stats and self._statistic_id in last_stats:
+            last_row = last_stats[self._statistic_id][0]
+            accumulated = last_row.get("sum") or 0
+            s = last_row.get("start") or 0
+            last_start_ts = s.timestamp() if isinstance(s, datetime) else float(s)
+        else:
+            accumulated = 0
+            last_start_ts = 0
+
+        def hour_block(dt: datetime) -> datetime:
+            # XX:00:00 states belong to previous hour block
+            if dt.minute == 0 and dt.second == 0:
+                dt = dt - timedelta(hours=1)
+            return dt.replace(minute=0, second=0, microsecond=0)
+
         #
         # Group historical states by hour
         # Calculate sum, mean, etc...
+        # Only process buckets after the last already-stored bucket.
         #
+        stat_data = []
+        for dt, group in itertools.groupby(hist, key=lambda x: hour_block(x[0])):
+            if dt.timestamp() <= last_start_ts:
+                continue
+            values = [v for _, v in group]
+            partial = sum(values)
+            accumulated += partial
+            stat_data.append(StatisticData(
+                start=dt,
+                state=partial,
+                mean=statistics.mean(values),
+                sum=accumulated,
+            ))
 
-        accumulated = (latest.get("sum") or 0) if latest else 0
+        if not stat_data:
+            return
 
-        def hour_block_for_hist_state(hist_state: HistoricalState) -> datetime:
-            # XX:00:00 states belongs to previous hour block
-            if hist_state.dt.minute == 0 and hist_state.dt.second == 0:
-                dt = hist_state.dt - timedelta(hours=1)
-                return dt.replace(minute=0, second=0, microsecond=0)
+        #
+        # Add sum and mean to statistics metadata.
+        # mean_type must be set explicitly to avoid HA 2026.11 deprecation warning (issue #14).
+        #
+        metadata = StatisticMetaData(
+            has_mean=True,
+            mean_type=StatisticMeanType.ARITHMETIC,
+            has_sum=True,
+            name=self._attr_name,
+            source=DOMAIN,
+            statistic_id=self._statistic_id,
+            unit_of_measurement=self._attr_native_unit_of_measurement,
+            unit_class=self._unit_class,
+        )
 
-            else:
-                return hist_state.dt.replace(minute=0, second=0, microsecond=0)
-
-        ret = []
-        for dt, collection_it in itertools.groupby(hist_states, key=hour_block_for_hist_state):
-            collection = list(collection_it)
-            mean = statistics.mean([x.state for x in collection])
-            partial_sum = sum([x.state for x in collection])
-            accumulated = accumulated + partial_sum
-
-            ret.append(
-                StatisticData(
-                    start=dt,
-                    state=partial_sum,
-                    mean=mean,
-                    sum=accumulated,
-                )
-            )
-
-        return ret
+        async_add_external_statistics(self.hass, metadata, stat_data)
+        LOGGER.info(f"Imported {len(stat_data)} new hourly stat buckets for {self._metric}")

--- a/custom_components/electric_ireland_insights/strings.json
+++ b/custom_components/electric_ireland_insights/strings.json
@@ -1,0 +1,45 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Electric Ireland Insights",
+        "description": "Enter your Electric Ireland account credentials.",
+        "data": {
+          "username": "Username (email)",
+          "password": "Password",
+          "account_number": "Account number",
+          "billing_day": "Billing cycle start day",
+          "lookup_days": "History to fetch (days)"
+        },
+        "data_description": {
+          "username": "The email address you use to log in to youraccountonline.electricireland.ie.",
+          "password": "Your Electric Ireland account password.",
+          "account_number": "Your Electric Ireland account number (e.g. 123456789).",
+          "billing_day": "Day of the month your billing cycle starts (1–31).",
+          "lookup_days": "How many days of historical data to fetch on each refresh (7–365)."
+        }
+      }
+    },
+    "error": {
+      "account_number_exists": "An entry for this account number already exists."
+    },
+    "abort": {
+      "already_configured": "This account is already configured."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Electric Ireland Insights options",
+        "data": {
+          "billing_day": "Billing cycle start day",
+          "lookup_days": "History to fetch (days)"
+        },
+        "data_description": {
+          "billing_day": "Day of the month your billing cycle starts (1–31).",
+          "lookup_days": "How many days of historical data to fetch on each refresh (7–365)."
+        }
+      }
+    }
+  }
+}

--- a/custom_components/electric_ireland_insights/translations/en.json
+++ b/custom_components/electric_ireland_insights/translations/en.json
@@ -1,0 +1,45 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Electric Ireland Insights",
+        "description": "Enter your Electric Ireland account credentials.",
+        "data": {
+          "username": "Username (email)",
+          "password": "Password",
+          "account_number": "Account number",
+          "billing_day": "Billing cycle start day",
+          "lookup_days": "History to fetch (days)"
+        },
+        "data_description": {
+          "username": "The email address you use to log in to youraccountonline.electricireland.ie.",
+          "password": "Your Electric Ireland account password.",
+          "account_number": "Your Electric Ireland account number (e.g. 123456789).",
+          "billing_day": "Day of the month your billing cycle starts (1–31).",
+          "lookup_days": "How many days of historical data to fetch on each refresh (7–365)."
+        }
+      }
+    },
+    "error": {
+      "account_number_exists": "An entry for this account number already exists."
+    },
+    "abort": {
+      "already_configured": "This account is already configured."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Electric Ireland Insights options",
+        "data": {
+          "billing_day": "Billing cycle start day",
+          "lookup_days": "History to fetch (days)"
+        },
+        "data_description": {
+          "billing_day": "Day of the month your billing cycle starts (1–31).",
+          "lookup_days": "How many days of historical data to fetch on each refresh (7–365)."
+        }
+      }
+    }
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 beautifulsoup4~=4.12.3
 homeassistant~=2025.12.1
-homeassistant-historical-sensor==2.0.0rc4
 requests>=2.32.3


### PR DESCRIPTION
Fixes #4, #13, #14

## Background

I ran into the StaleDataError (#4, #13) and eventually moved away from
this integration, writing a custom pyscript as a workaround. Since I
maintain a few HACS integrations myself, I figured contributing back was
the right thing to do rather than keeping the fix to myself.

## What changed

The `homeassistant-historical-sensor` library is replaced with
`DataUpdateCoordinator` + `async_add_external_statistics`. This removes
the race condition that caused recorder crashes on MariaDB and SQLite,
and fixes the `mean_type` deprecation that would break HA 2026.11.

The change is backward compatible — existing users get the fix on
upgrade with no configuration changes required.

## New features

- **Billing cycle sensors** — `consumption` and `cost` sensors scoped to
  the current billing period. Users just set the day their cycle starts
  (default: 1st of the month, configurable via the options flow).
- **Configurable history window** — fetch 7 to 365 days of data
  (default: 30). Useful for longer billing periods or historical analysis.
- **Options flow** — both settings are editable after setup without
  removing and re-adding the integration.
- **UI labels** — `strings.json` and `translations/en.json` so the
  config flow renders field names instead of raw keys.

## Notes

This is a relatively significant change but I've tested it against a
live HA instance with MariaDB. Happy to adjust anything or split it up
if preferred.

Thanks for maintaining this integration.