### PR TITLE
Fix: Add unit_class to statistic metadata

### DIFF
--- a/custom_components/electric_ireland_insights/sensor_base.py
+++ b/custom_components/electric_ireland_insights/sensor_base.py
@@ -145,6 +145,7 @@ class Sensor(PollUpdateMixin, HistoricalSensor, SensorEntity):
         meta = super().get_statistic_metadata()
         meta["has_sum"] = True
         meta["mean_type"] = StatisticMeanType.ARITHMETIC
+        meta["unit_class"] = str(self._attr_device_class) if str(self._attr_device_class) == "energy" else None
 
         return meta
 


### PR DESCRIPTION
This PR adds `unit_class` to the metadata in `sensor_base.py`. It sets it to `"energy"` for the Consumption sensor (since it is convertible) and to `None` for the Cost sensor (since Home Assistant rejects unit classes for `monetary` devices).

Without this change, the integration throws a `RuntimeError: Detected code that doesn't specify unit_class` and fails to save historical statistics (seems like HA recently introduced a change in the statistics API that requires `unit_class` to be explicitly provided when calling `async_import_statistics`).

Tested locally on Home Assistant 2026.6+ and confirmed that the `RuntimeError` disappears and historical statistics are successfully imported and displayed on the energy dashboard.